### PR TITLE
Ensure that a config.json exists when loading

### DIFF
--- a/PortableLcm.psm1
+++ b/PortableLcm.psm1
@@ -1188,6 +1188,27 @@ function Assert-DscMofConfig
 
 function Get-LcmConfig
 {
+    if (-not (Test-Path -Path $MofConfigPath))
+    {
+        if (-not (SplitPath -Path $MofConfigPath -Parent))
+        {
+            $null = New-Item -Path (SplitPath -Path $MofConfigPath -Parent) -ItemType 'Directory'
+        }
+
+        $config = [ordered]@{
+            Settings = @{
+                AllowReboot           = $true
+                Status                = 'Idle'
+                ProcessId             = $null
+                Cancel                = $false
+                CancelTimeoutInSeconds = 300
+            }
+            Configurations = @()
+        }
+
+        $config | ConvertTo-Json | Out-File -FilePath $configPath
+    }
+    
     return Get-Content -Path $MofConfigPath | ConvertFrom-Json -Depth 6 -WarningAction 'SilentlyContinue'
 }
 

--- a/PortableLcm.psm1
+++ b/PortableLcm.psm1
@@ -1190,9 +1190,9 @@ function Get-LcmConfig
 {
     if (-not (Test-Path -Path $MofConfigPath))
     {
-        if (-not (SplitPath -Path $MofConfigPath -Parent))
+        if (-not (Split-Path -Path $MofConfigPath -Parent))
         {
-            $null = New-Item -Path (SplitPath -Path $MofConfigPath -Parent) -ItemType 'Directory'
+            $null = New-Item -Path (Split-Path -Path $MofConfigPath -Parent) -ItemType 'Directory'
         }
 
         $config = [ordered]@{
@@ -1208,7 +1208,7 @@ function Get-LcmConfig
 
         $config | ConvertTo-Json | Out-File -FilePath $configPath
     }
-    
+
     return Get-Content -Path $MofConfigPath | ConvertFrom-Json -Depth 6 -WarningAction 'SilentlyContinue'
 }
 

--- a/PortableLcm.psm1
+++ b/PortableLcm.psm1
@@ -1188,7 +1188,9 @@ function Assert-DscMofConfig
 
 function Get-LcmConfig
 {
-    if (-not (Test-Path -Path $MofConfigPath))
+    $config = Get-Content -Path $MofConfigPath | ConvertFrom-Json -Depth 6 -WarningAction 'SilentlyContinue'
+    
+    if (-not (Test-Path -Path $MofConfigPath) -or ($null -eq $config))
     {
         if (-not (Split-Path -Path $MofConfigPath -Parent))
         {


### PR DESCRIPTION
If module is loaded and the config.json is wiped (due to error killing LCM, user actions, etc) then it needs to be recreated.

Taken from block at top of module, which can probably be removed, but I didn't test that, so I left as is.