### PR TITLE
Add Windows Event logs to follow LCM progress/errors.

### DIFF
--- a/PortableLcm.psd1
+++ b/PortableLcm.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PortableLcm.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.0.1'
+ModuleVersion = '0.0.2'
 
 # ID used to uniquely identify this module
 GUID = 'fa9cb268-0609-4c74-8fba-aa5a169c081e'

--- a/PortableLcm.psm1
+++ b/PortableLcm.psm1
@@ -11,6 +11,7 @@ data LocalizedData
     ParametersValidated = Parameters for resource '{0}' passed validation.
     ResourceValidated = Resource '{0}' passed validation.
     CallExternalFunction = Calling {0}-TargetResource for resource '{1}'.
+    ExternalFunctionError = Resource: {0}\n{1} Error: {2}.
     ParametersNotValidated = Parameters for resource '{0}' failed validation.
     ResourceNotInDesiredState = Resource '{0}' is not in desired state.
     ResourceInDesiredState = Resource '{0}' is in desired state.
@@ -505,7 +506,7 @@ function Test-MofResource
             }
             catch
             {
-                Write-Error -Exception $_.Exception -Message $_.Exception.Message
+                throw $_.Exception
             }
 
             if ($result)
@@ -595,6 +596,7 @@ function Set-MofResource
             catch
             {
                 $Resource.Exception = $_.Exception
+                throw $_.Exception
             }
 
             return $Resource
@@ -615,6 +617,42 @@ function Set-MofResource
         {
             #Remove-Module -FullyQualifiedName $tempFunction.Path
         }
+    }
+}
+
+function Write-EventLogEntry
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string]
+        $EntryMessage,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]
+        $EntryArguments,
+
+        [Parameter()]
+        [ValidateSet("Error", "Warning", "Information")]
+        $EntryType = "Information"
+    )
+
+    if ($env:OS -eq 'Windows_NT' -and $PSEdition -eq 'Desktop')
+    {
+        $eventParams = @{
+            Category = 8 # Pipeline Execution Details
+            EventId = 1000
+            LogName = "Windows PowerShell"
+            Source = "PowerShell"
+            Message = ($EntryMessage -f $EntryArguments)
+            EntryType = $EntryType
+        }
+        Write-EventLog @eventParams
+    }
+
+    if ($EntryType -in @("Error", "Warning"))
+    {
+        Write-Warning -Message ($EntryMessage -f $EntryArguments)
     }
 }
 
@@ -927,7 +965,7 @@ function Test-DscMofConfig
         {
             $updateResource.Exception = $_.Exception.Message
             $updateResource.InDesiredState = $false
-            Write-Error -Exception $_.Exception -Message $_.Exception.Message
+            Write-EventLogEntry -EntryMessage "$(`$LocalizedData.ExternalFunctionError)" -EntryArguments @($updateResource.ResourceId, "Test", $_.Exception.Message) -EntryType Error
         }
        
         $output += $result
@@ -1027,6 +1065,7 @@ function Assert-DscMofConfig
     )
 
     $verboseSetting = $PSCmdlet.MyInvocation.BoundParameters['Verbose'].IsPresent -and $PSCmdlet.MyInvocation.BoundParameters['Verbose']
+    Write-EventLogEntry -EntryMessage "Starting Portable LCM at {0}" -EntryArguments (Get-TimeStamp)
     New-Variable -Name 'DSCMachineStatus ' -Scope 'Global' -Value 0 -Force
     $lcm = Get-LcmConfig
     if ($lcm.Settings.Status -ne 'Idle' -and -not [string]::IsNullOrEmpty($lcm.Settings.ProcessId -and -not $Force))
@@ -1144,7 +1183,7 @@ function Assert-DscMofConfig
                 $updateResource.Exception = $_.Exception.Message
                 $updateResource.InDesiredState = $false
 
-                Write-Error -Exception $_.Exception -Message $_.Exception.Message
+                Write-EventLogEntry -EntryMessage "$($LocalizedData.ExternalFunctionError)" -EntryArguments @($updateResource.ResourceId,"Test", $_.Exception.Message) -EntryType Error
                 continue
             }
 
@@ -1187,6 +1226,7 @@ function Assert-DscMofConfig
     {
         Reset-Lcm
     }
+    Write-EventLogEntry -EntryMessage "Finishing Portable LCM at {0}" -EntryArguments (Get-TimeStamp)
 }
 
 function Get-LcmConfig


### PR DESCRIPTION
Write-Errors should now be Write-Warning, with the errors being logged explictly in the Windows Powershell event log.