### PR TITLE
Add Sqlite for Configuration and Result storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # PortableLcm
+This project attempts to create a LCM that works on both PowerShell 5.1 (Desktop) and PowerShell Core and is not tied to the Windows LCM
+
+## Features
+
+* Multiple MOF files can be published at once
+* Results are stored in SQLite, and can be exported to JSON with built in commands
+
+## Requirements
+
+* PSSQLIte module

--- a/src/PortableLcm.psd1
+++ b/src/PortableLcm.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PortableLcm.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.0.0.1'
+ModuleVersion = '0.0.3'
 
 # ID used to uniquely identify this module
 GUID = 'fa9cb268-0609-4c74-8fba-aa5a169c081e'
@@ -48,7 +48,8 @@ PowerShellVersion = '5.1'
 # ProcessorArchitecture = ''
 
 # Modules that must be imported into the global environment prior to importing this module
-RequiredModules = @(@{ModuleName = 'PSDesiredStateConfiguration'; ModuleVersion = '1.1'; })
+RequiredModules = @(@{ModuleName = 'PSDesiredStateConfiguration'; ModuleVersion = '1.1'; }
+@{ModuleName = 'PSSQLite'; ModuleVersion = '1.1.0'; })
 
 # Assemblies that must be loaded prior to importing this module
 # RequiredAssemblies = @()

--- a/src/config.sqlite.sql
+++ b/src/config.sqlite.sql
@@ -1,0 +1,53 @@
+PRAGMA foreign_keys = ON;
+
+BEGIN TRANSACTION;
+CREATE TABLE IF NOT EXISTS "Mofs" (
+	"ID"	INTEGER NOT NULL UNIQUE,
+	-- SHA256 hash of MOF file
+	"Hash"	TEXT NOT NULL UNIQUE,
+	"Name"	TEXT NOT NULL,
+	"PublishDate"	TEXT NOT NULL DEFAULT (datetime('now')),
+	"Mode"	TEXT NOT NULL DEFAULT 'ApplyAndMonitor',
+	"Active" NUMERIC DEFAULT '1',
+	PRIMARY KEY("ID" AUTOINCREMENT)
+);
+CREATE TABLE IF NOT EXISTS "Jobs" (
+	"ID"	INTEGER NOT NULL UNIQUE,
+	-- Comma separated list of MOFs
+	"Mof"	INTEGER NOT NULL,
+	"Mode"	TEXT,
+	"StartDate"	TEXT NOT NULL DEFAULT (datetime('now')),
+	"EndDate" TEXT,
+	FOREIGN KEY("Mof") REFERENCES "Mofs"("ID"),
+	PRIMARY KEY("ID" AUTOINCREMENT)
+);
+CREATE TABLE IF NOT EXISTS "CimInstances" (
+	"ID"	INTEGER NOT NULL UNIQUE,
+	"ResourceId"	TEXT,
+	-- SHA256 Hash of Mof file
+	"Mof"	INTEGER NOT NULL,
+	-- Instance Type - NTFSAccessEntry, RegisteryPolicyFile, etc
+	"Type"	TEXT,
+	-- DSC Module containing the type
+	"ModuleName"	TEXT,
+	-- The Module version specific in the MOF
+	"ModuleVersion"	TEXT,
+	-- Array of strings separated by comma
+	"DependsOn"	TEXT,
+	-- The CIMInstance serialized by PSSerializer to a depth of 100
+	"RawInstance"	BLOB,
+	FOREIGN KEY("Mof") REFERENCES "Mofs"("ID"),
+	PRIMARY KEY("ID" AUTOINCREMENT)
+);
+CREATE TABLE IF NOT EXISTS "Results" (
+	"ID"	INTEGER NOT NULL UNIQUE,
+	"Job"	INTEGER NOT NULL,
+	"CimInstance"	INTEGER,
+	"InDesiredState"	NUMERIC,
+	"Error"	TEXT,
+	"RunType"	NUMERIC,
+	FOREIGN KEY("CimInstance") REFERENCES "CimInstances"("ID"),
+	FOREIGN KEY("Job") REFERENCES "Jobs"("ID"),
+	PRIMARY KEY("ID" AUTOINCREMENT)
+);
+COMMIT;

--- a/src/exec_dsc.py
+++ b/src/exec_dsc.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+import os
+import sys
+import json
+import inspect
+cur = os.path.realpath(os.curdir)
+if 'OMI_HOME' in os.environ.keys():
+    prefix=os.environ['OMI_HOME']
+else:
+    prefix = '/opt/omi'
+    os.chdir(prefix + '/lib/Scripts')
+    sys.path.insert(0, '')
+if sys.version < '2.6':
+    os.chdir('./2.4x-2.5x')
+elif sys.version < '3':
+    os.chdir('./2.6x-2.7x')
+else:
+    os.chdir('./3.x')
+from Scripts import *
+
+the_module = globals()[sys.argv[1]]
+method_name = sys.argv[2] + '_Marshall'
+
+d = json.loads(sys.argv[3])
+
+argspec = inspect.getargspec(the_module.__dict__[method_name])
+if type(argspec) == tuple:
+    args = argspec[0]
+else:
+    args = argspec.args
+
+for arg in args:
+    if arg not in d.keys():
+        d[arg] = None
+for key in d.keys():
+    if key not in args:
+        d.pop(key)
+
+ret = the_module.__dict__[method_name](**d)
+print('Result:' + repr(ret[0]))


### PR DESCRIPTION
First attempt at replacing the JSON config file with SQLite.  The settings still exist in the settings.json, while configurations and results have been moved into SQLite.

This will enable more features like Configuration and Resource history, etc.

Also support for Linux clients was updated, should work with any system that has the DSC for Linux package installed.